### PR TITLE
Fix where `sessionid_ss` and `tt-target-idc` are not being used, causing `ScriptTagNotFoundError`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ Remember do not share this to anyone as this is a sensitive data tied to your Ti
 
 ## Issues
 
-### `StreamDataNotFoundError` occurs
+### `ScriptTagNotFoundError` or `StreamDataNotFoundError` occurs
 
-Sometimes, the program may raise an `StreamDataNotFoundError`. One of the possible reasons is that you might have repeatedly download live streams in a short amount of time (I'm not really sure with this one due to limited testing done by myself).
+Sometimes, the program may raise an `ScriptTagNotFoundError` or `StreamDataNotFoundError`. One of the possible reasons is that you might have repeatedly download live streams in a short amount of time (I'm not really sure with this one due to limited testing done by myself).
 
 To fix this, you have to supply a `sessionid_ss` and `tt-target-idc` based from your browser's cookies. You will put those in `user_data/config.toml` located in the project's folder. Refer to the guide above for detailed steps.
 

--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -36,8 +36,8 @@ class Mode(Enum):
 
 
 class ConfigKey(Enum):
-    SESSIONID_SS = "sessionid_ss",
-    TT_TARGET_IDC = "tt-target-idc",
+    SESSIONID_SS = "sessionid_ss"
+    TT_TARGET_IDC = "tt-target-idc"
     PROXY = "proxy"
 
 


### PR DESCRIPTION
Just noticed that even if you supplied `sessionid_ss` and `tt-target-idc` in the config.toml file, the program got None values regardless if it's empty or not. I found out that the enum class that i have set up in constants.py has comma for each constant, which accessing the value of the constant becomes tuple instead of string. Now, accessing the dictionary with tuple value throws an exception, and it is caught by KeyError that returns None.