### PR TITLE
Fix mypy issue with yt-dlp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,4 +20,5 @@ dev = [
     "pytest>=8.3.5",
     "types-requests>=2.32.0.20250328",
     "types-toml>=0.10.8.20240310",
+    "yt-dlp-types>=0.0.15",
 ]

--- a/tk3u8/model.py
+++ b/tk3u8/model.py
@@ -91,7 +91,7 @@ class Tk3u8:
         }
 
         try:
-            with YoutubeDL(ydl_opts) as ydl:
+            with YoutubeDL(ydl_opts) as ydl:  # type: ignore[arg-type]
                 ydl.download([stream_link.link])
                 print(f"\nFinished downloading {filename}.mp4")
         except Exception as e:

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ wheels = [
 
 [[package]]
 name = "tk3u8"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "bs4" },
@@ -323,6 +323,7 @@ dev = [
     { name = "pytest" },
     { name = "types-requests" },
     { name = "types-toml" },
+    { name = "yt-dlp-types" },
 ]
 
 [package.metadata]
@@ -341,6 +342,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "types-requests", specifier = ">=2.32.0.20250328" },
     { name = "types-toml", specifier = ">=0.10.8.20240310" },
+    { name = "yt-dlp-types", specifier = ">=0.0.15" },
 ]
 
 [[package]]
@@ -414,11 +416,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.0"
+version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/b00a62db91a83fff600de219b6ea9908e6918664899a2d85db222f4fbf19/typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b", size = 106520 }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/86/39b65d676ec5732de17b7e3c476e45bb80ec64eb50737a8dce1a4178aba1/typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5", size = 45683 },
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
 ]
 
 [[package]]
@@ -437,4 +439,16 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/11/333d16f88b1515d4c601e1dfbf1028e6798f0b2a8ff1dc5aaa7b797aa9e8/yt_dlp-2025.3.31.tar.gz", hash = "sha256:1bfe0e660d1a70a09e27b2d58f92e30b1e2e362cc487829f2f824346ae49fb91", size = 2967466 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/bf/7b0affb8f163376309696cfd1c677818fa0969fbb9d88225087208799afe/yt_dlp-2025.3.31-py3-none-any.whl", hash = "sha256:8ecb3aa218a3bebe431119f513a8972b9b9d992edf67168c00ab92329a03baec", size = 3226021 },
+]
+
+[[package]]
+name = "yt-dlp-types"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/39/665ba708f009e03a3c619f43704e99e1437121f9269f5a6f7a6861947e28/yt_dlp_types-0.0.15.tar.gz", hash = "sha256:8aaa25a081d39d89e93c480a569eefab59bb45ce2725eef19f1a7b521c985410", size = 10674 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/78/39754ac202a32211348dc0413f264b1926a9541dcc9c998011385536d419/yt_dlp_types-0.0.15-py3-none-any.whl", hash = "sha256:74c2b935eeef6225f7651bb2148410085a3dd310ce481049d8adcbbb0dc12cb3", size = 13022 },
 ]


### PR DESCRIPTION
This will fix mypy issue `error: Skipping analyzing "yt_dlp": module is installed, but missing library stubs or py.typed marker  [import-untyped]`.

Moreover, the with block will cause an arg-type error (i.e., `error: Argument 1 to "YoutubeDL" has incompatible type "dict[str, object]"; expected "YDLOpts"  [arg-type]`) for some reason. For that reason, this will be suppressed.