### PR TITLE
Raised an exception when the user is preparing for live

### DIFF
--- a/tk3u8/core/stream_metadata_handler.py
+++ b/tk3u8/core/stream_metadata_handler.py
@@ -14,6 +14,7 @@ from tk3u8.exceptions import (
     UnknownStatusCodeError,
     UserNotFoundError,
     UserNotLiveError,
+    UserPreparingForLiveError,
     WAFChallengeError
 )
 from tk3u8.options_handler import OptionsHandler
@@ -123,6 +124,8 @@ class StreamMetadataHandler:
     def is_user_live(self) -> bool:
         status = self._source_data["LiveRoom"]["liveRoomUserInfo"]["user"]["status"]
 
+        if status == 1:
+            raise UserPreparingForLiveError(status)
         if status == 2:
             return True
         elif status == 4:

--- a/tk3u8/exceptions.py
+++ b/tk3u8/exceptions.py
@@ -66,6 +66,15 @@ class NoUsernameEnteredError(Exception):
         super().__init__(self.message)
 
 
+class UserPreparingForLiveError(Exception):
+    """Custom exception when the user is preparing to go live.
+    """
+
+    def __init__(self, username) -> None:
+        self.message = f"User @{username} is preparing to go live. Try again in a minute or two to be able to download the stream."
+        super().__init__(self.message)
+
+
 class UnknownStatusCodeError(Exception):
     """Custom exception whenever the status code returned isn't 2 or 4.
 


### PR DESCRIPTION
I noticed this a few weeks ago that there is some instance that the user is preparing for live so in the initial code, if the program catches this behavior, it will raise an `UnknownStatusCodeError`. And I think it's better to catch this one properly.