### PR TITLE
Rework constants

### DIFF
--- a/tk3u8/args_handler.py
+++ b/tk3u8/args_handler.py
@@ -29,8 +29,8 @@ class ArgsHandler():
         )
         self._parser.add_argument(
             "-q",
-            choices=[quality.value.lower() for quality in Quality],
-            default=Quality.ORIGINAL.value.lower(),
+            choices=[quality.value for quality in Quality],
+            default=Quality.ORIGINAL.value,
             dest="quality",
             help="Specify the quality of the video to download. Default: original"
         )

--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -43,9 +43,9 @@ class OptionKey(Enum):
 # Default configuration settings
 DEFAULT_CONFIG = {
     "config": {
-        "sessionid_ss": "",
-        "tt-target-idc": "",
-        "proxy": ""
+        OptionKey.SESSIONID_SS.value: "",
+        OptionKey.TT_TARGET_IDC.value: "",
+        OptionKey.PROXY.value: ""
     }
 }
 

--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -21,13 +21,13 @@ class StatusCode(Enum):
 
 
 class Quality(Enum):
-    ORIGINAL = "Original"
-    UHD_60 = "UHD_60"
-    UHD = "UHD"
-    HD_60 = "HD_60"
-    HD = "HD"
-    LD = "LD"
-    SD = "SD"
+    ORIGINAL = "original"
+    UHD_60 = "uhd_60"
+    UHD = "uhd"
+    HD_60 = "hd_60"
+    HD = "hd"
+    LD = "ld"
+    SD = "sd"
 
 
 class OptionKey(Enum):

--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -32,7 +32,7 @@ class Quality(Enum):
 
 class OptionKey(Enum):
     SESSIONID_SS = "sessionid_ss"
-    TT_TARGET_IDC = "tt-target-idc"
+    TT_TARGET_IDC = "tt_target_idc"
     PROXY = "proxy"
     USERNAME = "username"
     QUALITY = "quality"

--- a/tk3u8/core/stream_metadata_handler.py
+++ b/tk3u8/core/stream_metadata_handler.py
@@ -104,7 +104,7 @@ class StreamMetadataHandler:
         replaced with "original".
         """
         stream_links = {}
-        qualities = [quality.value.lower() for quality in list(Quality)[1:]]
+        qualities = [quality.value for quality in list(Quality)[1:]]
         qualities.insert(0, "origin")
 
         for quality in qualities:

--- a/tk3u8/options_handler.py
+++ b/tk3u8/options_handler.py
@@ -18,7 +18,7 @@ class OptionsHandler:
                 OptionKey.TT_TARGET_IDC: lambda: self._config_values[OptionKey.TT_TARGET_IDC.value],
                 OptionKey.PROXY: lambda: self._args_values[OptionKey.PROXY.value] or self._config_values[OptionKey.PROXY.value],
                 OptionKey.USERNAME: lambda: self._args_values[OptionKey.USERNAME.value],
-                OptionKey.QUALITY: lambda: self._args_values[OptionKey.QUALITY.value.lower()],
+                OptionKey.QUALITY: lambda: self._args_values[OptionKey.QUALITY.value],
                 OptionKey.WAIT_UNTIL_LIVE: lambda: self._args_values[OptionKey.WAIT_UNTIL_LIVE.value],
                 OptionKey.TIMEOUT: lambda: self._args_values[OptionKey.TIMEOUT.value],
             }


### PR DESCRIPTION
This PR changes the values of some constants to lowercase values to avoid using `lower()` throughout the code. This also changes the default config file to use the keys from the `OptionKey` class to lessen hardcoded keys. With this change, if anyone is using a config file with their values set in there, it is advised to backup the values that you have set, and let the program recreate the config file. After that, you can put the values again in there.