### PR TITLE
Fix where `HLSLinkNotFoundError()` was unused

### DIFF
--- a/tk3u8/core/stream_metadata_handler.py
+++ b/tk3u8/core/stream_metadata_handler.py
@@ -113,6 +113,11 @@ class StreamMetadataHandler:
             except KeyError:
                 link = None
 
+            # Link can be an empty string. Based on my testing, this errpr
+            # will most likely to happen for those who live in the US region.
+            if link == "":
+                raise HLSLinkNotFoundError(self._username)
+
             stream_links.update({
                 quality: link
             })


### PR DESCRIPTION
After some refactoring made from #17, I forgot the exception handling of empty stream links, so here it is!