### PR TITLE
Change data dirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "bs4>=0.0.2",
+    "platformdirs>=4.3.8",
     "requests>=2.32.3",
     "rich>=12.6.0",
     "rich-argparse>=1.7.0",

--- a/tk3u8/logging.py
+++ b/tk3u8/logging.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 import logging
 import os
+
+from platformdirs import user_data_path
 from tk3u8 import logger
 
 
@@ -11,7 +13,7 @@ def setup_logging(log_level: str | None) -> None:
 
     logger.setLevel(logging.DEBUG)
 
-    log_directory = os.path.join("user_data", "logs")
+    log_directory = os.path.join(user_data_path(), "tk3u8", "logs")
 
     if not os.path.exists(log_directory):
         os.mkdir(log_directory)

--- a/tk3u8/path_initializer.py
+++ b/tk3u8/path_initializer.py
@@ -1,5 +1,6 @@
 import os
 import toml
+from platformdirs import user_data_path
 from tk3u8.constants import DEFAULT_CONFIG
 
 
@@ -23,7 +24,7 @@ class PathInitializer:
 
     def _set_base_dir(self, base_dir) -> None:
         # Set up main directory and file paths
-        self.PROGRAM_DATA_DIR = base_dir if base_dir else "user_data"
+        self.PROGRAM_DATA_DIR = base_dir if base_dir else self._get_default_base_path()
         self.CONFIG_FILE_PATH = os.path.join(self.PROGRAM_DATA_DIR, "config.toml")
         self.DOWNLOAD_DIR = os.path.join(self.PROGRAM_DATA_DIR, "downloads")
 
@@ -39,3 +40,6 @@ class PathInitializer:
         if not os.path.isfile(self.CONFIG_FILE_PATH):
             with open(self.CONFIG_FILE_PATH, "w") as file:
                 toml.dump(DEFAULT_CONFIG, file)
+
+    def _get_default_base_path(self) -> str:
+        return os.path.join(user_data_path(), "tk3u8")

--- a/tk3u8/path_initializer.py
+++ b/tk3u8/path_initializer.py
@@ -25,7 +25,7 @@ class PathInitializer:
     def _set_base_dir(self, base_dir) -> None:
         # Set up main directory and file paths
         self.PROGRAM_DATA_DIR = base_dir if base_dir else self._get_default_base_path()
-        self.CONFIG_FILE_PATH = os.path.join(self.PROGRAM_DATA_DIR, "config.toml")
+        self.CONFIG_FILE_PATH = os.path.join(self.PROGRAM_DATA_DIR, "tk3u8.conf")
         self.DOWNLOAD_DIR = os.path.join(self.PROGRAM_DATA_DIR, "downloads")
 
         self._initialize_paths()

--- a/tk3u8/path_initializer.py
+++ b/tk3u8/path_initializer.py
@@ -24,7 +24,6 @@ class PathInitializer:
     def _set_base_dir(self, base_dir) -> None:
         # Set up main directory and file paths
         self.PROGRAM_DATA_DIR = base_dir if base_dir else "user_data"
-        self.STREAM_DATA_FILE = os.path.join(self.PROGRAM_DATA_DIR, "stream_data.json")
         self.CONFIG_FILE_PATH = os.path.join(self.PROGRAM_DATA_DIR, "config.toml")
         self.DOWNLOAD_DIR = os.path.join(self.PROGRAM_DATA_DIR, "downloads")
 

--- a/tk3u8/path_initializer.py
+++ b/tk3u8/path_initializer.py
@@ -1,6 +1,6 @@
 import os
 import toml
-from platformdirs import user_data_path
+from platformdirs import user_data_path, user_downloads_path
 from tk3u8.constants import DEFAULT_CONFIG
 
 
@@ -26,7 +26,7 @@ class PathInitializer:
         # Set up main directory and file paths
         self.PROGRAM_DATA_DIR = base_dir if base_dir else self._get_default_base_path()
         self.CONFIG_FILE_PATH = os.path.join(self.PROGRAM_DATA_DIR, "tk3u8.conf")
-        self.DOWNLOAD_DIR = os.path.join(self.PROGRAM_DATA_DIR, "downloads")
+        self.DOWNLOAD_DIR = os.path.join(user_downloads_path(), "tk3u8")
 
         self._initialize_paths()
 

--- a/uv.lock
+++ b/uv.lock
@@ -278,6 +278,15 @@ wheels = [
 ]
 
 [[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload_time = "2025-05-07T22:47:42.121Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload_time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -380,6 +389,7 @@ version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "bs4" },
+    { name = "platformdirs" },
     { name = "requests" },
     { name = "rich" },
     { name = "rich-argparse" },
@@ -401,6 +411,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "bs4", specifier = ">=0.0.2" },
+    { name = "platformdirs", specifier = ">=4.3.8" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "rich", specifier = ">=12.6.0" },
     { name = "rich-argparse", specifier = ">=1.7.0" },


### PR DESCRIPTION
In this change, the program will store different kinds of data in appropriate directories. Config and logs files are now stored under:
- Windows: `C:\\Users\\username\\AppData\\Local\\tk3u8`
- Linux: `/home/username/.local/share/tk3u8`
- macOS: `/Users/trentm/Library/Application Support/`

These directories are handled by `platformdirs` library.

Additionally, all downloads are stored under user's download directory. For example, if you are a Windows user, you can see a `tk3u8` folder on your Downloads folder.