### PR TITLE
Update the way of printing CLI messages

### DIFF
--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -45,6 +45,32 @@ class OptionKey(Enum):
     TIMEOUT = "timeout"
 
 
+@dataclass
+class Messages:
+    user_offline: str = "User [b]@{username}[/b] is [red]currently offline[/red]."
+    preparing_to_go_live: str = "User [b]@{username}[/b] is preparing to go live. Try again in a minute or two to be able to download the stream."
+    user_is_now_live: str = "User [b]@{username}[/b] is now [b][green]streaming live[/b][/green]."
+    awaiting_to_go_live: str = "User [b]@{username}[/b] is [red]currently offline[/red]. Awaiting [b]@{username}[/b] to start streaming..."
+    quality_not_available: str = "[grey50]Cannot proceed with downloading. The chosen quality [b]({quality})[/b] is not available for download.[/grey50]"
+    starting_download: str = "Starting download for user [b]@{username}[/b] [grey50](quality: {stream_link.quality}, stream Link: {stream_link.link})[/grey50]"
+    finished_downloading: str = "[green]Finished downloading[/green] [b]{filename}.mp4[/b] [grey50](saved at: {filename_with_download_dir})[/grey50]"
+    cancelled_checking_live: str = "Checking cancelled by user. Exiting..."
+    retrying_to_check_live: str = "[bold yellow]Retrying in {remaining} seconds{seconds_extra_space}"
+    ongoing_checking_live: str = "Checking..."
+    processing_data: str = "Processing data..."
+    processing_data_for_user: str = "Processing data for user @{username}"
+    trying_extractor: str = "Trying extractor #{pos}: {extractor_class_name}"
+    current_extractor_failed: str = "[grey50]Extractor #{current_extr_pos} ({current_extr_name}) failed due to [b]{exc_name}[/b]. Trying next extractor method (Extractor #{next_extr_pos})[grey50]"
+    last_extractor_failed: str = "[grey50]Extractor #{current_extr_pos} ({current_extr_name}) failed due to [b]{exc_name}[/b]. No more extractors to be used. The program will now exit.[grey50]"
+    invalid_username: str = "The username [b]{username}[/b] is [red]invalid[/red]. Ensure the username is at least 2 characters long, contains only lowercase letters, numbers, underscores, and/or periods, and is up to 24 characters in length."
+    no_username_entered: str = "No username was entered. Please provide a valid username."
+    account_not_found: str = "User [b]@{username}[/b] is likely a private account, or it doesn't exist at all."
+    fetched_content: str = "Fetched content for user @{username}: {content}"
+    retrieved_stream_links: str = "Retrieved stream links for user @{username}: {stream_links}"
+    extracted_stream_data: str = "Extracted stream_data for user @{username}: {stream_data}"
+    extracted_status_code: str = "Extracted status_code for user @{username}: {status_code}"
+
+
 APP_NAME = "tk3u8"
 
 

--- a/tk3u8/core/extractor.py
+++ b/tk3u8/core/extractor.py
@@ -12,6 +12,7 @@ from tk3u8.exceptions import (
     UnknownStatusCodeError,
     WAFChallengeError
 )
+from tk3u8.messages import messages
 from tk3u8.session.request_handler import RequestHandler
 import logging
 
@@ -76,7 +77,10 @@ class Extractor(ABC):
 
         stream_links["original"] = stream_links.pop("origin")
 
-        logger.debug(f"Retrieved stream links for user @{self._username}: {stream_links}")
+        logger.debug(messages.retrieved_stream_links.format(
+            username=self._username,
+            stream_links=stream_links
+        ))
 
         return stream_links
 
@@ -99,14 +103,20 @@ class APIExtractor(Extractor):
         soup = BeautifulSoup(response.text, "html.parser")
         content = json.loads(soup.text)
 
-        logger.debug(f"Fetched content for user @{self._username}: {content}")
+        logger.debug(messages.fetched_content.format(
+            username=self._username,
+            content=content
+        ))
 
         return content
 
     def get_stream_data(self, source_data: dict) -> dict:
         try:
             stream_data = json.loads(source_data["data"]["liveRoom"]["streamData"]["pull_data"]["stream_data"])
-            logger.debug(f"Extracted stream_data for user @{self._username}: {stream_data}")
+            logger.debug(messages.extracted_stream_data.format(
+                username=self._username,
+                stream_data=stream_data
+            ))
 
             return stream_data
         except KeyError:
@@ -116,7 +126,10 @@ class APIExtractor(Extractor):
     def get_live_status(self, source_data: dict) -> LiveStatus:
         try:
             status_code = source_data["data"]["user"]["status"]
-            logger.debug(f"Extracted status_code for user @{self._username}: {status_code}")
+            logger.debug(messages.extracted_status_code.format(
+                username=self._username,
+                status_code=status_code
+            ))
 
             return self._get_live_status(status_code)
         except KeyError:
@@ -141,14 +154,20 @@ class WebpageExtractor(Extractor):
 
         content = json.loads(script_tag.text)
 
-        logger.debug(f"Fetched content for user @{self._username}: {content}")
+        logger.debug(messages.fetched_content.format(
+            username=self._username,
+            content=content
+        ))
 
         return content
 
     def get_stream_data(self, source_data: dict) -> dict:
         try:
             stream_data = json.loads(source_data["LiveRoom"]["liveRoomUserInfo"]["liveRoom"]["streamData"]["pull_data"]["stream_data"])
-            logger.debug(f"Extracted stream_data for user @{self._username}: {stream_data}")
+            logger.debug(messages.extracted_stream_data.format(
+                username=self._username,
+                stream_data=stream_data
+            ))
 
             return stream_data
         except KeyError:
@@ -158,7 +177,10 @@ class WebpageExtractor(Extractor):
     def get_live_status(self, source_data: dict) -> LiveStatus:
         try:
             status_code = source_data["LiveRoom"]["liveRoomUserInfo"]["user"]["status"]
-            logger.debug(f"Extracted status_code for user @{self._username}: {status_code}")
+            logger.debug(messages.extracted_status_code.format(
+                username=self._username,
+                status_code=status_code
+            ))
 
             return self._get_live_status(status_code)
         except KeyError:

--- a/tk3u8/messages.py
+++ b/tk3u8/messages.py
@@ -1,0 +1,4 @@
+from tk3u8.constants import Messages
+
+
+messages = Messages()


### PR DESCRIPTION
This commit changes the way the messages are printed in the CLI. Initially, errors such as invalid username or nonexisting accounts are printed in a way that it provides too many technical messages that might be a bit unnecessary for general users. With this change, the error is printed as a one-liner now, so it is more straightforward to read and understand.

Another change is that all of the messages being printed are now placed in the constants.py. This is to separate the actual logic for processing stuff from the presentation (which is the CLI messages being printed). In that way, the modules are not flooded with these hard-coded message strings.

With this approach, I created a dataclass that stores these messages. To be able to use this, I decided to create an instance of this class, in which this instance will be importable across several modules so that it is more resource friendly. (Actually, I should use enum instead of dataclass instead since I think it is more appropriate to do so for this stuff. Take note of this self.)