### PR TITLE
Improve config validation

### DIFF
--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -78,6 +78,7 @@ class Messages:
     extracted_status_code: str = "Extracted status_code for user @{username}: {status_code}"
     exiting_download_reattempt: str = "[grey50]Reattempting download cancelled by user. Exiting...[/grey50]"
     invalid_option_key: str = "Option key [b]{key}[/b] is invalid. Please ensure you entered a valid option key in your config file."
+    config_file_decoding_error: str = "Error decoding config file due to: '[yellow]{exc_msg}[/yellow]'"
 
 
 APP_NAME = "tk3u8"

--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -77,6 +77,7 @@ class Messages:
     extracted_stream_data: str = "Extracted stream_data for user @{username}: {stream_data}"
     extracted_status_code: str = "Extracted status_code for user @{username}: {status_code}"
     exiting_download_reattempt: str = "[grey50]Reattempting download cancelled by user. Exiting...[/grey50]"
+    invalid_option_key: str = "Option key [b]{key}[/b] is invalid. Please ensure you entered a valid option key in your config file."
 
 
 APP_NAME = "tk3u8"

--- a/tk3u8/options_handler.py
+++ b/tk3u8/options_handler.py
@@ -1,5 +1,7 @@
 from typing import Optional
 import toml
+from toml import TomlDecodeError
+from tk3u8 import logging
 from tk3u8.cli.console import console
 from tk3u8.constants import OptionKey
 from tk3u8.exceptions import FileParsingError
@@ -15,6 +17,8 @@ DEFAULT_VALUES = {
     OptionKey.TIMEOUT: 30,
     OptionKey.FORCE_REDOWNLOAD: False
 }
+
+logger = logging.getLogger(__name__)
 
 
 class OptionsHandler:
@@ -53,6 +57,14 @@ class OptionsHandler:
                 return config
         except FileNotFoundError:
             raise FileParsingError()
+        except TomlDecodeError as e:
+            exc_msg = f'{e.msg} (line {e.lineno} column {e.colno} char {e.pos})'
+            formatted_msg = messages.config_file_decoding_error.format(exc_msg=exc_msg)
+
+            console.print(formatted_msg)
+            logger.debug(formatted_msg)
+
+            exit(1)
 
     def _retouch_config_values(self, config: dict) -> dict:
         """Turns empty strings into None values"""
@@ -63,7 +75,7 @@ class OptionsHandler:
         for key, value in raw_config.items():
             if key not in option_keys:
                 console.print(messages.invalid_option_key.format(key=key))
-                exit(0)
+                exit(1)
 
             if value == "":
                 raw_config[key] = None

--- a/tk3u8/options_handler.py
+++ b/tk3u8/options_handler.py
@@ -1,7 +1,9 @@
 from typing import Optional
 import toml
+from tk3u8.cli.console import console
 from tk3u8.constants import OptionKey
 from tk3u8.exceptions import FileParsingError
+from tk3u8.messages import messages
 from tk3u8.path_initializer import PathInitializer
 
 
@@ -56,8 +58,13 @@ class OptionsHandler:
         """Turns empty strings into None values"""
 
         raw_config: dict = config['config']
+        option_keys = [option_key.value for option_key in OptionKey]
 
         for key, value in raw_config.items():
+            if key not in option_keys:
+                console.print(messages.invalid_option_key.format(key=key))
+                exit(0)
+
             if value == "":
                 raw_config[key] = None
 

--- a/tk3u8/options_handler.py
+++ b/tk3u8/options_handler.py
@@ -74,7 +74,10 @@ class OptionsHandler:
 
         for key, value in raw_config.items():
             if key not in option_keys:
-                console.print(messages.invalid_option_key.format(key=key))
+                msg = messages.invalid_option_key.format(key=key)
+                console.print(msg)
+                logger.debug(msg)
+
                 exit(1)
 
             if value == "":


### PR DESCRIPTION
This commit adds validation to option keys from the config file to let them know if they actually entered an invalid option key. Additionally, errors will be printed much better when there is problem reading the config file (e.g. it tells if there is a missing quotation, or some invalid characters somewhere)