### PR TITLE
Push pre-release builds for every update in main branch

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -7,6 +7,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+a[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+b[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+rc[0-9]+'
+    branches: [main]
   workflow_dispatch:
 
 jobs:
@@ -21,6 +22,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+      
+      # This ensures that version will be guessed properly with setuptools-scm
+      - name: Ensure full Git history and tags
+        run: |
+          git fetch --unshallow || true
+          git fetch --tags
 
       - name: Set up Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
In this PR, this will automatically create pre-release versions of the program that will be published to PyPI, allowing users to get the latest updates of the app without having to wait for every published stable release.