### PR TITLE
Fix `ConnectionError` on force redownload

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,18 @@ dev = [
 requires = ["setuptools", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
+[tool.ruff.lint]
+extend-select = [
+    "E302",
+    "E303",
+    "E305",
+]
+preview = true
+
+[tool.ruff.format]
+preview = true
+
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["tk3u8*"]
@@ -81,3 +93,4 @@ local_scheme = "no-local-version"
 
 [tool.uv]
 default-groups = []
+

--- a/tk3u8/core/stream_metadata_handler.py
+++ b/tk3u8/core/stream_metadata_handler.py
@@ -56,7 +56,8 @@ class StreamMetadataHandler:
             self._process_data(username)
 
     def update_data(self) -> None:
-        self._process_data()
+        with console.status(messages.processing_data):
+            self._process_data()
 
     def get_username(self) -> str:
         assert isinstance(self._username, str)

--- a/tk3u8/exceptions.py
+++ b/tk3u8/exceptions.py
@@ -8,8 +8,8 @@ class RequestFailedError(Exception):
     invalid responses, or other related errors.
     """
 
-    def __init__(self, status_code: int) -> None:
-        self.message = f" Request failed with status code: {status_code})"
+    def __init__(self, exc_msg: str) -> None:
+        self.message = f"Request failed: {exc_msg})"
         super().__init__(self.message)
 
 

--- a/tk3u8/session/request_handler.py
+++ b/tk3u8/session/request_handler.py
@@ -29,16 +29,15 @@ class RequestHandler:
     def __init__(self, options_handler: OptionsHandler) -> None:
         self._options_handler = options_handler
         self._initialize_session()
-        self._response: requests.Response | None = None
 
     def get_data(self, url: str) -> requests.Response:
-        self._response = self._session.get(url)
+        response = self._session.get(url)
 
-        if self._response.status_code != 200:
-            logger.exception(f"{RequestFailedError.__name__}: {RequestFailedError(self._response.status_code)}")
-            raise RequestFailedError(status_code=self._response.status_code)
+        if response.status_code != 200:
+            logger.exception(f"{RequestFailedError.__name__}: {RequestFailedError(response.status_code)}")
+            raise RequestFailedError(status_code=response.status_code)
 
-        return self._response
+        return response
 
     def update_proxy(self, proxy: str | None) -> None:
         if proxy:

--- a/tk3u8/session/request_handler.py
+++ b/tk3u8/session/request_handler.py
@@ -28,13 +28,8 @@ class RequestHandler:
     """
     def __init__(self, options_handler: OptionsHandler) -> None:
         self._options_handler = options_handler
-        self._session = requests.Session()
-        self._setup_cookies()
-        self._setup_proxy()
-        self._session.headers.update({
-            "User-Agent": self._get_random_user_agent()
-        })
-        self._response: requests.Response
+        self._initialize_session()
+        self._response: requests.Response | None = None
 
     def get_data(self, url: str) -> requests.Response:
         self._response = self._session.get(url)
@@ -61,6 +56,24 @@ class RequestHandler:
             })
         logger.debug(f"'sessionid_ss' cookie updated to: {sessionid_ss}")
         logger.debug(f"'sessionid_ss' cookie updated to: {tt_target_idc}")
+
+    def _initialize_session(self) -> None:
+        if hasattr(self, '_session') and self._session:
+            try:
+                self._session.close()
+                logger.debug("Previous requests' session closed.")
+            except Exception as e:
+                logger.warning(f"Error closing previous requests' session: {e}")
+
+        self._session = requests.Session()
+        self._setup_cookies()
+        self._setup_proxy()
+        self._session.headers.update({
+            "User-Agent": self._get_random_user_agent()
+        })
+
+        logger.debug("New requests.Session initialized.")
+
 
     def _setup_cookies(self) -> None:
         sessionid_ss = self._options_handler.get_option_val(OptionKey.SESSIONID_SS)

--- a/tk3u8/session/request_handler.py
+++ b/tk3u8/session/request_handler.py
@@ -28,6 +28,7 @@ class RequestHandler:
     """
     def __init__(self, options_handler: OptionsHandler) -> None:
         self._options_handler = options_handler
+        self._session: requests.Session
         self._initialize_session()
 
     def get_data(self, url: str) -> requests.Response:
@@ -104,7 +105,6 @@ class RequestHandler:
         })
 
         logger.debug("New requests.Session initialized.")
-
 
     def _setup_cookies(self) -> None:
         sessionid_ss = self._options_handler.get_option_val(OptionKey.SESSIONID_SS)


### PR DESCRIPTION
When using force redownload, there is a chance that the program will raise a `ConnectionError`. In this commit, this will fix it and is most likely will not happen again.