### PR TITLE
Allow downloading of HEVC-encoded stream

### DIFF
--- a/tk3u8/cli/args_handler.py
+++ b/tk3u8/cli/args_handler.py
@@ -57,6 +57,12 @@ class ArgsHandler():
             default=False
         )
         self._parser.add_argument(
+            "--use-h265",
+            action="store_true",
+            help="Use the H.265 (HEVC) encoded live stream instead of H.264 (AVC)",
+            default=False
+        )
+        self._parser.add_argument(
             "--log-level",
             help="Set the logging level (default: no logging if not used)",
             choices=["DEBUG", "ERROR"],

--- a/tk3u8/cli/main.py
+++ b/tk3u8/cli/main.py
@@ -15,6 +15,7 @@ def start_cli() -> None:
     timeout = args.timeout
     log_level = args.log_level
     force_redownload = args.force_redownload
+    use_h265 = args.use_h265
 
     setup_logging(log_level)
 
@@ -25,5 +26,6 @@ def start_cli() -> None:
         quality=quality,
         wait_until_live=wait_until_live,
         timeout=timeout,
-        force_redownload=force_redownload
+        force_redownload=force_redownload,
+        use_h265=use_h265
     )

--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -56,6 +56,7 @@ class Messages:
     reattempting_download: str = "[grey50]Reattempting download for user [b]@{username}[/b]...[/grey50]"
     awaiting_to_go_live: str = "User [b]@{username}[/b] is [red]currently offline[/red]. Awaiting [b]@{username}[/b] to start streaming..."
     quality_not_available: str = "[grey50]Cannot proceed with downloading. The chosen quality [b]({quality})[/b] is not available for download.[/grey50]"
+    empty_stream_link_error: str = "Cannot proceed with downloading as the stream link was somehow unavailable during stream data extraction. Try downloading again."
     starting_download: str = "Starting download for user [b]@{username}[/b] [grey50](quality: {stream_link.quality}, stream Link: {stream_link.link})[/grey50]"
     finished_downloading: str = "[green]Finished downloading[/green] [b]{filename}.mp4[/b] [grey50](saved at: {filename_with_download_dir})[/grey50]"
     cancelled_checking_live: str = "[grey50]Checking cancelled by user. Exiting...[/grey50]"

--- a/tk3u8/constants.py
+++ b/tk3u8/constants.py
@@ -44,6 +44,7 @@ class OptionKey(Enum):
     WAIT_UNTIL_LIVE = "wait_until_live"
     TIMEOUT = "timeout"
     FORCE_REDOWNLOAD = "force_redownload"
+    USE_H265 = "use_h265"
 
 
 @dataclass

--- a/tk3u8/core/downloader.py
+++ b/tk3u8/core/downloader.py
@@ -31,11 +31,13 @@ class Downloader:
         live_status = self._stream_metadata_handler.get_live_status()
         force_redownload = self._options_handler.get_option_val(OptionKey.FORCE_REDOWNLOAD)
         redownload_attempted = False
+        use_h265 = self._options_handler.get_option_val(OptionKey.USE_H265)
 
         assert isinstance(username, str)
         assert isinstance(wait_until_live, int)
         assert isinstance(live_status, LiveStatus)
         assert isinstance(force_redownload, bool)
+        assert isinstance(use_h265, bool)
 
         while True:
             if live_status in (LiveStatus.OFFLINE, LiveStatus.PREPARING_TO_GO_LIVE):
@@ -60,7 +62,7 @@ class Downloader:
             else:
                 console.print(messages.reattempting_download.format(username=username))
 
-            stream_link = self._stream_metadata_handler.get_stream_link(quality)
+            stream_link = self._stream_metadata_handler.get_stream_link(quality, use_h265)
             if not self._is_stream_link_available(stream_link):
                 console.print(messages.quality_not_available.format(quality=quality))
                 logger.error(f"{QualityNotAvailableError.__name__}: {QualityNotAvailableError()}")

--- a/tk3u8/core/model.py
+++ b/tk3u8/core/model.py
@@ -51,7 +51,8 @@ class Tk3u8:
             quality: str = Quality.ORIGINAL.value,
             wait_until_live: bool = False,
             timeout: int = 30,
-            force_redownload: bool = False
+            force_redownload: bool = False,
+            use_h265: bool = False
     ) -> None:
         """
         Downloads a stream for the specified user with the given quality and options.
@@ -70,7 +71,8 @@ class Tk3u8:
         self._options_handler.save_args_values(
             wait_until_live=wait_until_live,
             timeout=timeout,
-            force_redownload=force_redownload
+            force_redownload=force_redownload,
+            use_h265=use_h265
         )
         self._stream_metadata_handler.initialize_data(username)
         self._downloader.download(quality)

--- a/tk3u8/core/stream_metadata_handler.py
+++ b/tk3u8/core/stream_metadata_handler.py
@@ -69,11 +69,11 @@ class StreamMetadataHandler:
 
         return self._live_status
 
-    def get_stream_link(self, quality: str) -> StreamLink:
+    def get_stream_link(self, quality: str, use_h265: bool = False) -> StreamLink:
         try:
             if quality in self._stream_links:
-                stream_link = StreamLink(quality, self._stream_links[quality])
-                logger.debug(f"Chosen stream link: {stream_link}")
+                stream_link = StreamLink(quality, self._stream_links[quality]["h265"] if use_h265 else self._stream_links[quality]["h264"])
+                logger.debug(f"Chosen stream link: {stream_link} ({'H.265' if use_h265 else 'H.264'})")
 
                 return stream_link
             logger.exception(f"{InvalidQualityError.__name__}: {InvalidQualityError}")

--- a/tk3u8/exceptions.py
+++ b/tk3u8/exceptions.py
@@ -145,6 +145,21 @@ class HLSLinkNotFoundError(Exception):
         super().__init__(self.message)
 
 
+class HLSLinkTemporarilyUnavailableError(Exception):
+    """Custom exception when the HLS stream link isn't available temporarily
+    for some reason.
+
+    The difference with the exception 'HLSLinkNotFoundError' is that this exception
+    will be used if the HLS link becomes unavaiable initially, but becomes available
+    again whenever user retries to download the live stream. The other exception is
+    only used if there is no actually available HLS stream links persistently.
+    """
+
+    def __init__(self) -> None:
+        self.message = "Cannot proceed with downloading as the stream link was somehow unavailable during stream data extraction. Try downloading again."
+        super().__init__(self.message)
+
+
 class InvalidArgKeyError(Exception):
     """Custom exception when an invalid key is encountered."""
 

--- a/tk3u8/options_handler.py
+++ b/tk3u8/options_handler.py
@@ -42,7 +42,7 @@ class OptionsHandler:
         self._args_values: dict = {}
         self._config_values: dict = self._load_config_values()
 
-    def get_option_val(self, key: OptionKey) -> Optional[str | int]:
+    def get_option_val(self, key: OptionKey) -> Optional[str | int | bool]:
         """
         Retrieves the value for a given option key, checking arguments first, then config file,
         and finally falling back to default values.


### PR DESCRIPTION
In this PR, users can now download a HEVC-encoded stream instead of the typical AVC-encoded ones (this is the default codec that is used in your downloaded streams). You just need to add `--use-h265` from the command-line and the program will download the HEVC ones if applicable. Otherwise, it will print a message saying that it is not available.

I have tried downloading a stream for both codecs, and based on testing, I don't see a major quality differences between the two. Both offer similar file sizes, so I don't really see why they offer HEVC-encoded streams. As there is no really benefit from using this, I still continue to do this just for the sake of allowing users to have more options and we don't know if TikTok might change the way they encode their streams in this codec.